### PR TITLE
fix: include sql files in package data

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "esdc"
-version = "0.3.0"
+version = "0.3.1"
 description = "Agentic chat interface for Indonesian oil & gas reserves database (ESDC)"
 requires-python = ">=3.10"
 authors = [
@@ -58,7 +58,7 @@ esdc = "esdc.esdc:app"
 where = ["."]
 
 [tool.setuptools.package-data]
-esdc = ["data/*"]
+esdc = ["sql/*"]
 
 [tool.setuptools.exclude-package-data]
 esdc = ["tests"]


### PR DESCRIPTION
## Changes
- Fixed package data configuration to include sql/* files instead of non-existent data/*
- Bumped version from 0.3.0 to 0.3.1

## Problem
File SQL di folder esdc/sql/ tidak terikut saat instalasi karena tidak didefinisikan di package-data.

## Solution
Mengubah [tool.setuptools.package-data] dari "data/*" menjadi "sql/*" di pyproject.toml.